### PR TITLE
Update TS version to support TS Satisfies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,9 +103,6 @@ dist
 # TernJS port file
 .tern-port
 
-# Build files
-lib/
-
 .idea
 
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Why the Dooly fork? We're looking to support TS `satisfies`. Once the plugin is updated to TS v4.9 we can likely revet back to the original package.
+
 # Prettier plugin sort imports
 
 A prettier plugin to sort import declarations by provided Regular Expression order.
@@ -8,47 +10,46 @@ A prettier plugin to sort import declarations by provided Regular Expression ord
 
 ```javascript
 import React, {
-    FC,
-    useEffect,
-    useRef,
-    ChangeEvent,
-    KeyboardEvent,
-} from 'react';
-import { logger } from '@core/logger';
-import { reduce, debounce } from 'lodash';
-import { Message } from '../Message';
-import { createServer } from '@server/node';
-import { Alert } from '@ui/Alert';
-import { repeat, filter, add } from '../utils';
-import { initializeApp } from '@core/app';
-import { Popup } from '@ui/Popup';
-import { createConnection } from '@server/database';
+  FC,
+  useEffect,
+  useRef,
+  ChangeEvent,
+  KeyboardEvent,
+} from "react";
+import { logger } from "@core/logger";
+import { reduce, debounce } from "lodash";
+import { Message } from "../Message";
+import { createServer } from "@server/node";
+import { Alert } from "@ui/Alert";
+import { repeat, filter, add } from "../utils";
+import { initializeApp } from "@core/app";
+import { Popup } from "@ui/Popup";
+import { createConnection } from "@server/database";
 ```
-
 
 ### Output
 
 ```javascript
-import { debounce, reduce } from 'lodash';
+import { debounce, reduce } from "lodash";
 import React, {
-    ChangeEvent,
-    FC,
-    KeyboardEvent,
-    useEffect,
-    useRef,
-} from 'react';
+  ChangeEvent,
+  FC,
+  KeyboardEvent,
+  useEffect,
+  useRef,
+} from "react";
 
-import { createConnection } from '@server/database';
-import { createServer } from '@server/node';
+import { createConnection } from "@server/database";
+import { createServer } from "@server/node";
 
-import { initializeApp } from '@core/app';
-import { logger } from '@core/logger';
+import { initializeApp } from "@core/app";
+import { logger } from "@core/logger";
 
-import { Alert } from '@ui/Alert';
-import { Popup } from '@ui/Popup';
+import { Alert } from "@ui/Alert";
+import { Popup } from "@ui/Popup";
 
-import { Message } from '../Message';
-import { add, filter, repeat } from '../utils';
+import { Message } from "../Message";
+import { add, filter, repeat } from "../utils";
 ```
 
 ### Install
@@ -213,15 +214,15 @@ Having some trouble or an issue ? You can check [FAQ / Troubleshooting section](
 | React                  | ✅ Everything            | -                                                |
 | Angular                | ✅ Everything            | Supported through `importOrderParserPlugins` API |
 | Vue                    | ✅ Everything            | `@vue/compiler-sfc` is required                  |
-| Svelte                 | ⚠️ Soon to be supported.  | Any contribution is welcome.                     |
+| Svelte                 | ⚠️ Soon to be supported. | Any contribution is welcome.                     |
 
 ### Used by
 
 Want to highlight your project or company ? Adding your project / company name will help plugin to gain attraction and contribution.
 Feel free to make a Pull Request to add your project / company name.
 
--   [trivago](https://company.trivago.com)
--   [AuresKonnect](https://aures.com)
+- [trivago](https://company.trivago.com)
+- [AuresKonnect](https://aures.com)
 
 ### Contribution
 

--- a/lib/src/constants.js
+++ b/lib/src/constants.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.newLineNode = exports.THIRD_PARTY_MODULES_SPECIAL_WORD = exports.newLineCharacters = exports.jsx = exports.typescript = exports.flow = void 0;
+var types_1 = require("@babel/types");
+exports.flow = 'flow';
+exports.typescript = 'typescript';
+exports.jsx = 'jsx';
+exports.newLineCharacters = '\n\n';
+/*
+ * Used to mark the position between RegExps,
+ * where the not matched imports should be placed
+ */
+exports.THIRD_PARTY_MODULES_SPECIAL_WORD = '<THIRD_PARTY_MODULES>';
+var PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE = 'PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE';
+exports.newLineNode = (0, types_1.expressionStatement)((0, types_1.stringLiteral)(PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE));

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -1,0 +1,70 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var parser_babel_1 = require("prettier/parser-babel");
+var parser_flow_1 = require("prettier/parser-flow");
+var parser_typescript_1 = require("prettier/parser-typescript");
+var parser_html_1 = require("prettier/parser-html");
+var default_processor_1 = require("./preprocessors/default-processor");
+var vue_preprocessor_1 = require("./preprocessors/vue-preprocessor");
+var options = {
+    importOrder: {
+        type: 'path',
+        category: 'Global',
+        array: true,
+        default: [{ value: [] }],
+        description: 'Provide an order to sort imports.',
+    },
+    importOrderCaseInsensitive: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Provide a case sensitivity boolean flag',
+    },
+    importOrderParserPlugins: {
+        type: 'path',
+        category: 'Global',
+        array: true,
+        // By default, we add ts and jsx as parsers but if users define something
+        // we take that option
+        default: [{ value: ['typescript', 'jsx'] }],
+        description: 'Provide a list of plugins for special syntax',
+    },
+    importOrderSeparation: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Should imports be separated by new line?',
+    },
+    importOrderGroupNamespaceSpecifiers: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Should namespace specifiers be grouped at the top of their group?',
+    },
+    importOrderSortSpecifiers: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Should specifiers be sorted?',
+    },
+};
+module.exports = {
+    parsers: {
+        babel: __assign(__assign({}, parser_babel_1.parsers.babel), { preprocess: default_processor_1.defaultPreprocessor }),
+        flow: __assign(__assign({}, parser_flow_1.parsers.flow), { preprocess: default_processor_1.defaultPreprocessor }),
+        typescript: __assign(__assign({}, parser_typescript_1.parsers.typescript), { preprocess: default_processor_1.defaultPreprocessor }),
+        vue: __assign(__assign({}, parser_html_1.parsers.vue), { preprocess: vue_preprocessor_1.vuePreprocessor }),
+    },
+    options: options,
+};

--- a/lib/src/natural-sort/index.js
+++ b/lib/src/natural-sort/index.js
@@ -1,0 +1,8 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.naturalSort = void 0;
+var javascript_natural_sort_1 = __importDefault(require("javascript-natural-sort"));
+exports.naturalSort = javascript_natural_sort_1.default;

--- a/lib/src/preprocessors/default-processor.js
+++ b/lib/src/preprocessors/default-processor.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultPreprocessor = void 0;
+var preprocessor_1 = require("./preprocessor");
+function defaultPreprocessor(code, options) {
+    var _a;
+    if ((_a = options.filepath) === null || _a === void 0 ? void 0 : _a.endsWith('.vue'))
+        return code;
+    return (0, preprocessor_1.preprocessor)(code, options);
+}
+exports.defaultPreprocessor = defaultPreprocessor;

--- a/lib/src/preprocessors/preprocessor.js
+++ b/lib/src/preprocessors/preprocessor.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.preprocessor = void 0;
+var parser_1 = require("@babel/parser");
+var extract_ast_nodes_1 = require("../utils/extract-ast-nodes");
+var get_code_from_ast_1 = require("../utils/get-code-from-ast");
+var get_experimental_parser_plugins_1 = require("../utils/get-experimental-parser-plugins");
+var get_sorted_nodes_1 = require("../utils/get-sorted-nodes");
+function preprocessor(code, options) {
+    var importOrderParserPlugins = options.importOrderParserPlugins, importOrder = options.importOrder, importOrderCaseInsensitive = options.importOrderCaseInsensitive, importOrderSeparation = options.importOrderSeparation, importOrderGroupNamespaceSpecifiers = options.importOrderGroupNamespaceSpecifiers, importOrderSortSpecifiers = options.importOrderSortSpecifiers;
+    var parserOptions = {
+        sourceType: 'module',
+        plugins: (0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)(importOrderParserPlugins),
+    };
+    var ast = (0, parser_1.parse)(code, parserOptions);
+    var interpreter = ast.program.interpreter;
+    var _a = (0, extract_ast_nodes_1.extractASTNodes)(ast), importNodes = _a.importNodes, directives = _a.directives;
+    // short-circuit if there are no import declaration
+    if (importNodes.length === 0)
+        return code;
+    var allImports = (0, get_sorted_nodes_1.getSortedNodes)(importNodes, {
+        importOrder: importOrder,
+        importOrderCaseInsensitive: importOrderCaseInsensitive,
+        importOrderSeparation: importOrderSeparation,
+        importOrderGroupNamespaceSpecifiers: importOrderGroupNamespaceSpecifiers,
+        importOrderSortSpecifiers: importOrderSortSpecifiers,
+    });
+    return (0, get_code_from_ast_1.getCodeFromAst)(allImports, directives, code, interpreter);
+}
+exports.preprocessor = preprocessor;

--- a/lib/src/preprocessors/vue-preprocessor.js
+++ b/lib/src/preprocessors/vue-preprocessor.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.vuePreprocessor = void 0;
+var preprocessor_1 = require("./preprocessor");
+function vuePreprocessor(code, options) {
+    var _a, _b;
+    var parse = require('@vue/compiler-sfc').parse;
+    var descriptor = parse(code).descriptor;
+    var content = (_b = ((_a = descriptor.script) !== null && _a !== void 0 ? _a : descriptor.scriptSetup)) === null || _b === void 0 ? void 0 : _b.content;
+    if (!content) {
+        return code;
+    }
+    return code.replace(content, "\n".concat((0, preprocessor_1.preprocessor)(content, options), "\n"));
+}
+exports.vuePreprocessor = vuePreprocessor;

--- a/lib/src/types.js
+++ b/lib/src/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/src/utils/__tests__/get-all-comments-from-nodes.spec.js
+++ b/lib/src/utils/__tests__/get-all-comments-from-nodes.spec.js
@@ -1,0 +1,42 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var get_all_comments_from_nodes_1 = require("../get-all-comments-from-nodes");
+var get_import_nodes_1 = require("../get-import-nodes");
+var get_sorted_nodes_1 = require("../get-sorted-nodes");
+var getSortedImportNodes = function (code, options) {
+    var importNodes = (0, get_import_nodes_1.getImportNodes)(code, options);
+    return (0, get_sorted_nodes_1.getSortedNodes)(importNodes, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+};
+var getComments = function (commentNodes) {
+    return commentNodes.map(function (node) { return node.value; });
+};
+test('it returns empty array when there is no comment', function () {
+    var result = getSortedImportNodes("import z from 'z';\n    ");
+    var commentNodes = (0, get_all_comments_from_nodes_1.getAllCommentsFromNodes)(result);
+    var comments = getComments(commentNodes);
+    expect(comments).toEqual([]);
+});
+test('it returns single comment of a node', function () {
+    var result = getSortedImportNodes("// first comment\nimport z from 'z';\n");
+    var commentNodes = (0, get_all_comments_from_nodes_1.getAllCommentsFromNodes)(result);
+    var comments = getComments(commentNodes);
+    expect(comments).toEqual([' first comment']);
+});
+test('it returns all comments for a node', function () {
+    var result = getSortedImportNodes("// first comment\n// second comment\nimport z from 'z';\n");
+    var commentNodes = (0, get_all_comments_from_nodes_1.getAllCommentsFromNodes)(result);
+    var comments = getComments(commentNodes);
+    expect(comments).toEqual([' first comment', ' second comment']);
+});
+test('it returns comment block for a node', function () {
+    var result = getSortedImportNodes("\n/**\n * some block\n */\nimport z from 'z';\n");
+    var commentNodes = (0, get_all_comments_from_nodes_1.getAllCommentsFromNodes)(result);
+    var comments = getComments(commentNodes);
+    expect(comments).toEqual(['*\n * some block\n ']);
+});

--- a/lib/src/utils/__tests__/get-code-from-ast.spec.js
+++ b/lib/src/utils/__tests__/get-code-from-ast.spec.js
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = require("@babel/core");
+var prettier_1 = require("prettier");
+var extract_ast_nodes_1 = require("../extract-ast-nodes");
+var get_code_from_ast_1 = require("../get-code-from-ast");
+var get_experimental_parser_plugins_1 = require("../get-experimental-parser-plugins");
+var get_import_nodes_1 = require("../get-import-nodes");
+var get_sorted_nodes_1 = require("../get-sorted-nodes");
+test('it sorts imports correctly', function () {
+    var code = "// first comment\n// second comment\nimport z from 'z';\nimport c from 'c';\nimport g from 'g';\nimport t from 't';\nimport k from 'k';\nimport a from 'a';\n";
+    var importNodes = (0, get_import_nodes_1.getImportNodes)(code);
+    var sortedNodes = (0, get_sorted_nodes_1.getSortedNodes)(importNodes, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    var formatted = (0, get_code_from_ast_1.getCodeFromAst)(sortedNodes, [], code, null);
+    expect((0, prettier_1.format)(formatted, { parser: 'babel' })).toEqual("// first comment\n// second comment\nimport a from \"a\";\nimport c from \"c\";\nimport g from \"g\";\nimport k from \"k\";\nimport t from \"t\";\nimport z from \"z\";\n");
+});
+test('it renders directives correctly', function () {
+    var code = "\n    \"use client\";\n// first comment\nimport b from 'b';\nimport a from 'a';";
+    var parserOptions = {
+        sourceType: 'module',
+        plugins: (0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)([]),
+    };
+    var ast = (0, core_1.parse)(code, parserOptions);
+    if (!ast)
+        throw new Error('ast is null');
+    var _a = (0, extract_ast_nodes_1.extractASTNodes)(ast), directives = _a.directives, importNodes = _a.importNodes;
+    var formatted = (0, get_code_from_ast_1.getCodeFromAst)(importNodes, directives, code, null);
+    expect((0, prettier_1.format)(formatted, { parser: 'babel' })).toEqual("\"use client\";\n\n// first comment\nimport b from \"b\";\nimport a from \"a\";\n");
+});

--- a/lib/src/utils/__tests__/get-experimental-parser-plugins.spec.js
+++ b/lib/src/utils/__tests__/get-experimental-parser-plugins.spec.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var get_experimental_parser_plugins_1 = require("../get-experimental-parser-plugins");
+test('it should return empty list', function () {
+    expect((0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)([])).toEqual([]);
+});
+test('it should return flow and decorators', function () {
+    expect((0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)(['flow', 'decorators'])).toEqual([
+        'flow',
+        'decorators',
+    ]);
+});
+test('it should return decorators with parsed options', function () {
+    expect((0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)([
+        '["decorators", { "decoratorsBeforeExport": true }]',
+    ])).toEqual([['decorators', { decoratorsBeforeExport: true }]]);
+});
+test('it should return decorators with parsed options', function () {
+    expect((0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)([
+        'flow',
+        '["decorators", { "decoratorsBeforeExport": true }]',
+    ])).toEqual(['flow', ['decorators', { decoratorsBeforeExport: true }]]);
+});
+test('it should throw an Error for invalid JSON', function () {
+    expect(function () {
+        return (0, get_experimental_parser_plugins_1.getExperimentalParserPlugins)([
+            'flow',
+            '["decorators", { decoratorsBeforeExport: true }]',
+        ]);
+    }).toThrowError('Invalid JSON in importOrderParserPlugins: ');
+});

--- a/lib/src/utils/__tests__/get-import-nodes-matched-group.spec.js
+++ b/lib/src/utils/__tests__/get-import-nodes-matched-group.spec.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var get_import_nodes_1 = require("../get-import-nodes");
+var get_import_nodes_matched_group_1 = require("../get-import-nodes-matched-group");
+var code = "// first comment\n// second comment\nimport z from '@server/z';\nimport c from '@server/c';\nimport g from '@ui/g';\nimport t from '@core/t';\nimport k from 'k';\nimport j from './j';\nimport l from './l';\nimport a from '@core/a';\n";
+test('should return correct matched groups', function () {
+    var importNodes = (0, get_import_nodes_1.getImportNodes)(code);
+    var importOrder = [
+        '^@server/(.*)$',
+        '^@core/(.*)$',
+        '^@ui/(.*)$',
+        '^[./]',
+    ];
+    var matchedGroups = [];
+    for (var _i = 0, importNodes_1 = importNodes; _i < importNodes_1.length; _i++) {
+        var importNode = importNodes_1[_i];
+        var matchedGroup = (0, get_import_nodes_matched_group_1.getImportNodesMatchedGroup)(importNode, importOrder);
+        matchedGroups.push(matchedGroup);
+    }
+    expect(matchedGroups).toEqual([
+        '^@server/(.*)$',
+        '^@server/(.*)$',
+        '^@ui/(.*)$',
+        '^@core/(.*)$',
+        '<THIRD_PARTY_MODULES>',
+        '^[./]',
+        '^[./]',
+        '^@core/(.*)$',
+    ]);
+});
+test('should return THIRD_PARTY_MODULES as matched group with empty order list', function () {
+    var importNodes = (0, get_import_nodes_1.getImportNodes)(code);
+    var importOrder = [];
+    for (var _i = 0, importNodes_2 = importNodes; _i < importNodes_2.length; _i++) {
+        var importNode = importNodes_2[_i];
+        var matchedGroup = (0, get_import_nodes_matched_group_1.getImportNodesMatchedGroup)(importNode, importOrder);
+        expect(matchedGroup).toEqual('<THIRD_PARTY_MODULES>');
+    }
+});

--- a/lib/src/utils/__tests__/get-sorted-import-specifiers.spec.js
+++ b/lib/src/utils/__tests__/get-sorted-import-specifiers.spec.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var get_import_nodes_1 = require("../get-import-nodes");
+var get_sorted_import_specifiers_1 = require("../get-sorted-import-specifiers");
+var get_sorted_nodes_modules_names_1 = require("../get-sorted-nodes-modules-names");
+test('should return correct sorted nodes', function () {
+    var code = "import { filter, reduce, eventHandler } from '@server/z';";
+    var importNode = (0, get_import_nodes_1.getImportNodes)(code)[0];
+    var sortedImportSpecifiers = (0, get_sorted_import_specifiers_1.getSortedImportSpecifiers)(importNode);
+    var specifiersList = (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(sortedImportSpecifiers.specifiers);
+    expect(specifiersList).toEqual(['eventHandler', 'filter', 'reduce']);
+});
+test('should return correct sorted nodes with default import', function () {
+    var code = "import Component, { filter, reduce, eventHandler } from '@server/z';";
+    var importNode = (0, get_import_nodes_1.getImportNodes)(code)[0];
+    var sortedImportSpecifiers = (0, get_sorted_import_specifiers_1.getSortedImportSpecifiers)(importNode);
+    var specifiersList = (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(sortedImportSpecifiers.specifiers);
+    expect(specifiersList).toEqual([
+        'Component',
+        'eventHandler',
+        'filter',
+        'reduce',
+    ]);
+});

--- a/lib/src/utils/__tests__/get-sorted-nodes.spec.js
+++ b/lib/src/utils/__tests__/get-sorted-nodes.spec.js
@@ -1,0 +1,293 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var get_import_nodes_1 = require("../get-import-nodes");
+var get_sorted_nodes_1 = require("../get-sorted-nodes");
+var get_sorted_nodes_modules_names_1 = require("../get-sorted-nodes-modules-names");
+var get_sorted_nodes_names_1 = require("../get-sorted-nodes-names");
+var code = "// first comment\n// second comment\nimport z from 'z';\nimport c, { cD } from 'c';\nimport g from 'g';\nimport { tC, tA, tB } from 't';\nimport k, { kE, kB } from 'k';\nimport * as a from 'a';\nimport * as x from 'x';\nimport BY from 'BY';\nimport Ba from 'Ba';\nimport XY from 'XY';\nimport Xa from 'Xa';\n";
+test('it returns all sorted nodes', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'BY',
+        'Ba',
+        'XY',
+        'Xa',
+        'a',
+        'c',
+        'g',
+        'k',
+        't',
+        'x',
+        'z',
+    ]);
+    expect(sorted
+        .filter(function (node) { return node.type === 'ImportDeclaration'; })
+        .map(function (importDeclaration) {
+        return (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(importDeclaration.specifiers);
+    })).toEqual([
+        ['BY'],
+        ['Ba'],
+        ['XY'],
+        ['Xa'],
+        ['a'],
+        ['c', 'cD'],
+        ['g'],
+        ['k', 'kE', 'kB'],
+        ['tC', 'tA', 'tB'],
+        ['x'],
+        ['z'],
+    ]);
+});
+test('it returns all sorted nodes case-insensitive', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: [],
+        importOrderCaseInsensitive: true,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'k',
+        't',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+    ]);
+    expect(sorted
+        .filter(function (node) { return node.type === 'ImportDeclaration'; })
+        .map(function (importDeclaration) {
+        return (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(importDeclaration.specifiers);
+    })).toEqual([
+        ['a'],
+        ['Ba'],
+        ['BY'],
+        ['c', 'cD'],
+        ['g'],
+        ['k', 'kE', 'kB'],
+        ['tC', 'tA', 'tB'],
+        ['x'],
+        ['Xa'],
+        ['XY'],
+        ['z'],
+    ]);
+});
+test('it returns all sorted nodes with sort order', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'x',
+        'z',
+        'a',
+        't',
+        'k',
+        'BY',
+        'Ba',
+    ]);
+    expect(sorted
+        .filter(function (node) { return node.type === 'ImportDeclaration'; })
+        .map(function (importDeclaration) {
+        return (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(importDeclaration.specifiers);
+    })).toEqual([
+        ['XY'],
+        ['Xa'],
+        ['c', 'cD'],
+        ['g'],
+        ['x'],
+        ['z'],
+        ['a'],
+        ['tC', 'tA', 'tB'],
+        ['k', 'kE', 'kB'],
+        ['BY'],
+        ['Ba'],
+    ]);
+});
+test('it returns all sorted nodes with sort order case-insensitive', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: true,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'c',
+        'g',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        'a',
+        't',
+        'k',
+        'Ba',
+        'BY',
+    ]);
+    expect(sorted
+        .filter(function (node) { return node.type === 'ImportDeclaration'; })
+        .map(function (importDeclaration) {
+        return (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(importDeclaration.specifiers);
+    })).toEqual([
+        ['c', 'cD'],
+        ['g'],
+        ['x'],
+        ['Xa'],
+        ['XY'],
+        ['z'],
+        ['a'],
+        ['tC', 'tA', 'tB'],
+        ['k', 'kE', 'kB'],
+        ['Ba'],
+        ['BY'],
+    ]);
+});
+test('it returns all sorted import nodes with sorted import specifiers', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: true,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'x',
+        'z',
+        'a',
+        't',
+        'k',
+        'BY',
+        'Ba',
+    ]);
+    expect(sorted
+        .filter(function (node) { return node.type === 'ImportDeclaration'; })
+        .map(function (importDeclaration) {
+        return (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(importDeclaration.specifiers);
+    })).toEqual([
+        ['XY'],
+        ['Xa'],
+        ['c', 'cD'],
+        ['g'],
+        ['x'],
+        ['z'],
+        ['a'],
+        ['tA', 'tB', 'tC'],
+        ['k', 'kB', 'kE'],
+        ['BY'],
+        ['Ba'],
+    ]);
+});
+test('it returns all sorted import nodes with sorted import specifiers with case-insensitive ', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: true,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: true,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'c',
+        'g',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        'a',
+        't',
+        'k',
+        'Ba',
+        'BY',
+    ]);
+    expect(sorted
+        .filter(function (node) { return node.type === 'ImportDeclaration'; })
+        .map(function (importDeclaration) {
+        return (0, get_sorted_nodes_modules_names_1.getSortedNodesModulesNames)(importDeclaration.specifiers);
+    })).toEqual([
+        ['c', 'cD'],
+        ['g'],
+        ['x'],
+        ['Xa'],
+        ['XY'],
+        ['z'],
+        ['a'],
+        ['tA', 'tB', 'tC'],
+        ['k', 'kB', 'kE'],
+        ['Ba'],
+        ['BY'],
+    ]);
+});
+test('it returns all sorted nodes with custom third party modules', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$'],
+        importOrderSeparation: false,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        't',
+        'k',
+    ]);
+});
+test('it returns all sorted nodes with namespace specifiers at the top', function () {
+    var result = (0, get_import_nodes_1.getImportNodes)(code);
+    var sorted = (0, get_sorted_nodes_1.getSortedNodes)(result, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: true,
+        importOrderSortSpecifiers: false,
+    });
+    expect((0, get_sorted_nodes_names_1.getSortedNodesNames)(sorted)).toEqual([
+        'a',
+        'x',
+        'BY',
+        'Ba',
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'k',
+        't',
+        'z',
+    ]);
+});

--- a/lib/src/utils/__tests__/remove-nodes-from-original-code.spec.js
+++ b/lib/src/utils/__tests__/remove-nodes-from-original-code.spec.js
@@ -1,0 +1,32 @@
+"use strict";
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var prettier_1 = require("prettier");
+var get_all_comments_from_nodes_1 = require("../get-all-comments-from-nodes");
+var get_import_nodes_1 = require("../get-import-nodes");
+var get_sorted_nodes_1 = require("../get-sorted-nodes");
+var remove_nodes_from_original_code_1 = require("../remove-nodes-from-original-code");
+var code = "// first comment\n// second comment\nimport z from 'z';\nimport c from 'c';\nimport g from 'g';\nimport t from 't';\nimport k from 'k';\n// import a from 'a';\n  // import a from 'a';\nimport a from 'a';\n";
+test('it should remove nodes from the original code', function () {
+    var importNodes = (0, get_import_nodes_1.getImportNodes)(code);
+    var sortedNodes = (0, get_sorted_nodes_1.getSortedNodes)(importNodes, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+    });
+    var allCommentsFromImports = (0, get_all_comments_from_nodes_1.getAllCommentsFromNodes)(sortedNodes);
+    var commentAndImportsToRemoveFromCode = __spreadArray(__spreadArray([], sortedNodes, true), allCommentsFromImports, true);
+    var codeWithoutImportDeclarations = (0, remove_nodes_from_original_code_1.removeNodesFromOriginalCode)(code, commentAndImportsToRemoveFromCode);
+    var result = (0, prettier_1.format)(codeWithoutImportDeclarations, { parser: 'babel' });
+    expect(result).toEqual('');
+});

--- a/lib/src/utils/extract-ast-nodes.js
+++ b/lib/src/utils/extract-ast-nodes.js
@@ -1,0 +1,30 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.extractASTNodes = void 0;
+var traverse_1 = __importDefault(require("@babel/traverse"));
+var types_1 = require("@babel/types");
+function extractASTNodes(ast) {
+    var importNodes = [];
+    var directives = [];
+    (0, traverse_1.default)(ast, {
+        Directive: function (_a) {
+            var node = _a.node;
+            directives.push(node);
+            // Trailing comments probably shouldn't be attached to the directive
+            node.trailingComments = null;
+        },
+        ImportDeclaration: function (path) {
+            var tsModuleParent = path.findParent(function (p) {
+                return (0, types_1.isTSModuleDeclaration)(p);
+            });
+            if (!tsModuleParent) {
+                importNodes.push(path.node);
+            }
+        },
+    });
+    return { importNodes: importNodes, directives: directives };
+}
+exports.extractASTNodes = extractASTNodes;

--- a/lib/src/utils/get-all-comments-from-nodes.js
+++ b/lib/src/utils/get-all-comments-from-nodes.js
@@ -1,0 +1,22 @@
+"use strict";
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAllCommentsFromNodes = void 0;
+var getAllCommentsFromNodes = function (nodes) {
+    return nodes.reduce(function (acc, node) {
+        if (Array.isArray(node.leadingComments) &&
+            node.leadingComments.length > 0) {
+            acc = __spreadArray(__spreadArray([], acc, true), node.leadingComments, true);
+        }
+        return acc;
+    }, []);
+};
+exports.getAllCommentsFromNodes = getAllCommentsFromNodes;

--- a/lib/src/utils/get-code-from-ast.js
+++ b/lib/src/utils/get-code-from-ast.js
@@ -1,0 +1,50 @@
+"use strict";
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getCodeFromAst = void 0;
+var generator_1 = __importDefault(require("@babel/generator"));
+var types_1 = require("@babel/types");
+var constants_1 = require("../constants");
+var get_all_comments_from_nodes_1 = require("./get-all-comments-from-nodes");
+var remove_nodes_from_original_code_1 = require("./remove-nodes-from-original-code");
+/**
+ * This function generate a code string from the passed nodes.
+ * @param nodes all imports
+ * @param originalCode
+ */
+var getCodeFromAst = function (nodes, directives, originalCode, interpreter) {
+    var allCommentsFromImports = (0, get_all_comments_from_nodes_1.getAllCommentsFromNodes)(nodes);
+    var nodesToRemoveFromCode = __spreadArray(__spreadArray(__spreadArray(__spreadArray([], directives, true), nodes, true), allCommentsFromImports, true), (interpreter ? [interpreter] : []), true);
+    var codeWithoutImportsAndInterpreter = (0, remove_nodes_from_original_code_1.removeNodesFromOriginalCode)(originalCode, nodesToRemoveFromCode);
+    var newAST = (0, types_1.file)({
+        type: 'Program',
+        body: nodes,
+        directives: directives,
+        sourceType: 'module',
+        interpreter: interpreter,
+        sourceFile: '',
+        leadingComments: [],
+        innerComments: [],
+        trailingComments: [],
+        start: 0,
+        end: 0,
+        loc: {
+            start: { line: 0, column: 0 },
+            end: { line: 0, column: 0 },
+        },
+    });
+    var code = (0, generator_1.default)(newAST).code;
+    return (code.replace(/"PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";/gi, constants_1.newLineCharacters) + codeWithoutImportsAndInterpreter.trim());
+};
+exports.getCodeFromAst = getCodeFromAst;

--- a/lib/src/utils/get-experimental-parser-plugins.js
+++ b/lib/src/utils/get-experimental-parser-plugins.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getExperimentalParserPlugins = void 0;
+/**
+ * Returns a list of babel parser plugin names
+ * @param importOrderParserPlugins array of experimental babel parser plugins
+ * @returns list of parser plugins to be passed to babel parser
+ */
+var getExperimentalParserPlugins = function (importOrderParserPlugins) {
+    return importOrderParserPlugins.map(function (pluginNameOrJson) {
+        // ParserPlugin can be either a string or and array of [name: string, options: object]
+        // in prettier options the array will be sent in a JSON string
+        var isParserPluginWithOptions = pluginNameOrJson.startsWith('[');
+        var plugin;
+        if (isParserPluginWithOptions) {
+            try {
+                plugin = JSON.parse(pluginNameOrJson);
+            }
+            catch (e) {
+                throw Error('Invalid JSON in importOrderParserPlugins: ' +
+                    pluginNameOrJson);
+            }
+        }
+        else {
+            plugin = pluginNameOrJson;
+        }
+        return plugin;
+    });
+};
+exports.getExperimentalParserPlugins = getExperimentalParserPlugins;

--- a/lib/src/utils/get-import-nodes-matched-group.js
+++ b/lib/src/utils/get-import-nodes-matched-group.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getImportNodesMatchedGroup = void 0;
+var constants_1 = require("../constants");
+/**
+ * Get the regexp group to keep the import nodes.
+ * @param node
+ * @param importOrder
+ */
+var getImportNodesMatchedGroup = function (node, importOrder) {
+    var groupWithRegExp = importOrder.map(function (group) { return ({
+        group: group,
+        regExp: new RegExp(group),
+    }); });
+    for (var _i = 0, groupWithRegExp_1 = groupWithRegExp; _i < groupWithRegExp_1.length; _i++) {
+        var _a = groupWithRegExp_1[_i], group = _a.group, regExp = _a.regExp;
+        var matched = node.source.value.match(regExp) !== null;
+        if (matched)
+            return group;
+    }
+    return constants_1.THIRD_PARTY_MODULES_SPECIAL_WORD;
+};
+exports.getImportNodesMatchedGroup = getImportNodesMatchedGroup;

--- a/lib/src/utils/get-import-nodes.js
+++ b/lib/src/utils/get-import-nodes.js
@@ -1,0 +1,36 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getImportNodes = void 0;
+var parser_1 = require("@babel/parser");
+var traverse_1 = __importDefault(require("@babel/traverse"));
+var types_1 = require("@babel/types");
+var getImportNodes = function (code, options) {
+    var importNodes = [];
+    var ast = (0, parser_1.parse)(code, __assign(__assign({}, options), { sourceType: 'module' }));
+    (0, traverse_1.default)(ast, {
+        ImportDeclaration: function (path) {
+            var tsModuleParent = path.findParent(function (p) {
+                return (0, types_1.isTSModuleDeclaration)(p);
+            });
+            if (!tsModuleParent) {
+                importNodes.push(path.node);
+            }
+        },
+    });
+    return importNodes;
+};
+exports.getImportNodes = getImportNodes;

--- a/lib/src/utils/get-sorted-import-specifiers.js
+++ b/lib/src/utils/get-sorted-import-specifiers.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getSortedImportSpecifiers = void 0;
+var natural_sort_1 = require("../natural-sort");
+/**
+ * This function returns import nodes with alphabetically sorted module
+ * specifiers
+ * @param node Import declaration node
+ */
+var getSortedImportSpecifiers = function (node) {
+    node.specifiers.sort(function (a, b) {
+        if (a.type !== b.type) {
+            return a.type === 'ImportDefaultSpecifier' ? -1 : 1;
+        }
+        return (0, natural_sort_1.naturalSort)(a.local.name, b.local.name);
+    });
+    return node;
+};
+exports.getSortedImportSpecifiers = getSortedImportSpecifiers;

--- a/lib/src/utils/get-sorted-nodes-group.js
+++ b/lib/src/utils/get-sorted-nodes-group.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getSortedNodesGroup = void 0;
+var natural_sort_1 = require("../natural-sort");
+var getSortedNodesGroup = function (imports, options) {
+    return imports.sort(function (a, b) {
+        if (options.importOrderGroupNamespaceSpecifiers) {
+            var diff = namespaceSpecifierSort(a, b);
+            if (diff !== 0)
+                return diff;
+        }
+        return (0, natural_sort_1.naturalSort)(a.source.value, b.source.value);
+    });
+};
+exports.getSortedNodesGroup = getSortedNodesGroup;
+function namespaceSpecifierSort(a, b) {
+    var aFirstSpecifier = a.specifiers.find(function (s) { return s.type === 'ImportNamespaceSpecifier'; })
+        ? 1
+        : 0;
+    var bFirstSpecifier = b.specifiers.find(function (s) { return s.type === 'ImportNamespaceSpecifier'; })
+        ? 1
+        : 0;
+    return bFirstSpecifier - aFirstSpecifier;
+}

--- a/lib/src/utils/get-sorted-nodes-modules-names.js
+++ b/lib/src/utils/get-sorted-nodes-modules-names.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getSortedNodesModulesNames = void 0;
+var getSortedNodesModulesNames = function (modules) {
+    return modules
+        .filter(function (m) {
+        return [
+            'ImportSpecifier',
+            'ImportDefaultSpecifier',
+            'ImportNamespaceSpecifier',
+        ].includes(m.type);
+    })
+        .map(function (m) { return m.local.name; });
+}; // TODO: get from specifier
+exports.getSortedNodesModulesNames = getSortedNodesModulesNames;

--- a/lib/src/utils/get-sorted-nodes-names.js
+++ b/lib/src/utils/get-sorted-nodes-names.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getSortedNodesNames = void 0;
+var getSortedNodesNames = function (imports) {
+    return imports
+        .filter(function (i) { return i.type === 'ImportDeclaration'; })
+        .map(function (i) { return i.source.value; });
+}; // TODO: get from specifier
+exports.getSortedNodesNames = getSortedNodesNames;

--- a/lib/src/utils/get-sorted-nodes.js
+++ b/lib/src/utils/get-sorted-nodes.js
@@ -1,0 +1,95 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getSortedNodes = void 0;
+var types_1 = require("@babel/types");
+var lodash_1 = require("lodash");
+var constants_1 = require("../constants");
+var natural_sort_1 = require("../natural-sort");
+var get_import_nodes_matched_group_1 = require("./get-import-nodes-matched-group");
+var get_sorted_import_specifiers_1 = require("./get-sorted-import-specifiers");
+var get_sorted_nodes_group_1 = require("./get-sorted-nodes-group");
+/**
+ * This function returns all the nodes which are in the importOrder array.
+ * The plugin considered these import nodes as local import declarations.
+ * @param nodes all import nodes
+ * @param options
+ */
+var getSortedNodes = function (nodes, options) {
+    natural_sort_1.naturalSort.insensitive = options.importOrderCaseInsensitive;
+    var importOrder = options.importOrder;
+    var importOrderSeparation = options.importOrderSeparation, importOrderSortSpecifiers = options.importOrderSortSpecifiers, importOrderGroupNamespaceSpecifiers = options.importOrderGroupNamespaceSpecifiers;
+    var originalNodes = nodes.map(lodash_1.clone);
+    var finalNodes = [];
+    if (!importOrder.includes(constants_1.THIRD_PARTY_MODULES_SPECIAL_WORD)) {
+        importOrder = __spreadArray([constants_1.THIRD_PARTY_MODULES_SPECIAL_WORD], importOrder, true);
+    }
+    var importOrderGroups = importOrder.reduce(function (groups, regexp) {
+        var _a;
+        return (__assign(__assign({}, groups), (_a = {}, _a[regexp] = [], _a)));
+    }, {});
+    var importOrderWithOutThirdPartyPlaceholder = importOrder.filter(function (group) { return group !== constants_1.THIRD_PARTY_MODULES_SPECIAL_WORD; });
+    for (var _i = 0, originalNodes_1 = originalNodes; _i < originalNodes_1.length; _i++) {
+        var node = originalNodes_1[_i];
+        var matchedGroup = (0, get_import_nodes_matched_group_1.getImportNodesMatchedGroup)(node, importOrderWithOutThirdPartyPlaceholder);
+        importOrderGroups[matchedGroup].push(node);
+    }
+    for (var _a = 0, importOrder_1 = importOrder; _a < importOrder_1.length; _a++) {
+        var group = importOrder_1[_a];
+        var groupNodes = importOrderGroups[group];
+        if (groupNodes.length === 0)
+            continue;
+        var sortedInsideGroup = (0, get_sorted_nodes_group_1.getSortedNodesGroup)(groupNodes, {
+            importOrderGroupNamespaceSpecifiers: importOrderGroupNamespaceSpecifiers,
+        });
+        // Sort the import specifiers
+        if (importOrderSortSpecifiers) {
+            sortedInsideGroup.forEach(function (node) {
+                return (0, get_sorted_import_specifiers_1.getSortedImportSpecifiers)(node);
+            });
+        }
+        finalNodes.push.apply(finalNodes, sortedInsideGroup);
+        if (importOrderSeparation) {
+            finalNodes.push(constants_1.newLineNode);
+        }
+    }
+    if (finalNodes.length > 0 && !importOrderSeparation) {
+        // a newline after all imports
+        finalNodes.push(constants_1.newLineNode);
+    }
+    // maintain a copy of the nodes to extract comments from
+    var finalNodesClone = finalNodes.map(lodash_1.clone);
+    var firstNodesComments = nodes[0].leadingComments;
+    // Remove all comments from sorted nodes
+    finalNodes.forEach(types_1.removeComments);
+    // insert comments other than the first comments
+    finalNodes.forEach(function (node, index) {
+        if ((0, lodash_1.isEqual)(nodes[0].loc, node.loc))
+            return;
+        (0, types_1.addComments)(node, 'leading', finalNodesClone[index].leadingComments || []);
+    });
+    if (firstNodesComments) {
+        (0, types_1.addComments)(finalNodes[0], 'leading', firstNodesComments);
+    }
+    return finalNodes;
+};
+exports.getSortedNodes = getSortedNodes;

--- a/lib/src/utils/remove-nodes-from-original-code.js
+++ b/lib/src/utils/remove-nodes-from-original-code.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.removeNodesFromOriginalCode = void 0;
+/** Escapes a string literal to be passed to new RegExp. See: https://stackoverflow.com/a/6969486/480608.
+ * @param s the string to escape
+ */
+var escapeRegExp = function (s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); };
+/**
+ * Removes imports from original file
+ * @param code the whole file as text
+ * @param nodes to be removed
+ */
+var removeNodesFromOriginalCode = function (code, nodes) {
+    var text = code;
+    for (var _i = 0, nodes_1 = nodes; _i < nodes_1.length; _i++) {
+        var node = nodes_1[_i];
+        var start = Number(node.start);
+        var end = Number(node.end);
+        if (Number.isSafeInteger(start) && Number.isSafeInteger(end)) {
+            text = text.replace(
+            // only replace imports at the beginning of the line (ignoring whitespace)
+            // otherwise matching commented imports will be replaced
+            new RegExp('^\\s*' + escapeRegExp(code.substring(start, end)), 'm'), '');
+        }
+    }
+    return text;
+};
+exports.removeNodesFromOriginalCode = removeNodesFromOriginalCode;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest": "26.6.3",
     "prettier": "2.8",
     "ts-jest": "26.5.3",
-    "typescript": "4.2.3"
+    "typescript": "4.9.5"
   },
   "peerDependencies": {
     "prettier": "2.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3381,10 +3381,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
TS satisfies was added in v4.9. This lib causes errors with code using `satisfies`.

This lib seems to have a very slow release cycle so handling this update ourselves is probably the fastest solution.